### PR TITLE
Add ec2 instances provisioning and management

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,14 @@ Create ansible setup for secure server with ownCloud, webserver (nginx), LDAP an
 ## Roles
 For this purpose the stack will contain some roles.
 
-- common (iptables, fail2ban, notifying about behavior using mail)
-- webserver (nginx, letsencrypt)
-- cloud (php, mysql/postgress and owncloud server)
-- authentication (OpenLDAP?)
-- mail (Postfix?)
+-   common (iptables, fail2ban, notifying about behavior using mail)
+-   webserver (nginx, letsencrypt)
+-   cloud (php, mysql/postgress and owncloud server)
+-   authentication (OpenLDAP?)
+-   mail (Postfix?)
+
+## EC2 Management and Provisioning Notes
+
+In order to run `amazon.yml` EC2 provisioning playbook you need to install and configure [boto](https://github.com/boto/boto3boto) python library.
+
+Also pay attention to the `vars` section where you need to specify the instance type, image, aws region, etc... for instances you want to spawn.

--- a/amazon.yml
+++ b/amazon.yml
@@ -1,0 +1,55 @@
+---
+- name: Create ad-hoc AWS EC2 Instances
+  hosts: localhost
+  connection: local
+  gather_facts: False
+
+  vars:
+    key_name: <key-pair-name>
+    instance_type: <ec2-instance-type-code>
+    instance_image: <ec2-instance-image>
+    instance_num: <number-of-spawned-instances>
+    region: <aws-region-code>
+    security_group: <custom-security-group>
+    vpc: <ec2-vpc-subnet-here>
+    aws_tag: <aws-instance-tags>
+
+  tasks:
+    - name: Launch specific ec2 instances
+      ec2:
+        key_name: "{{ key_name }}"
+        group: "{{ security_group }}"
+        instance_type: "{{ instance_type }}"
+        image: "{{ instance_image }}"
+        wait: yes
+        region: "{{ region }}"
+        vpc_subnet_id: "{{ vpc }}"
+        assign_public_ip: yes
+        instance_tags:
+          type: "{{ aws_tag }}"
+        exact_count: "{{ instance_num }}"
+        count_tag:
+          type: "{{ aws_tag }}"
+      register: servers
+
+    - name: Add all new instance to host group for later use
+      add_host:
+        hostname: "{{ item.public_ip }}"
+        groups: launched
+      with_items: "{{ servers.instances }}"
+
+
+    - name: Wait for SSH on all instances to come up
+      wait_for:
+        host: "{{ item.public_dns_name }}"
+        port: 22
+        delay: 60
+        timeout: 320
+        state: started
+      with_items: "{{ servers.instances }}"
+
+    - name: Terminate instances that were previously launched
+      ec2:
+        region: "{{ region }}"
+        instance_ids: "{{ servers.instance_ids }}"
+        state: 'absent'


### PR DESCRIPTION
I have created a simple ansible playbook for spawning and killing EC2 instances. This is very usefull if you want to write some other playbooks because you can then test them on ad-hoc instances or in scale.

The script itself creates specified instances, waits for ssh to come up and then kills them. Some tasks can be inserted before killing for testing purposes.